### PR TITLE
Updated index.md as suggested on the issue#25890

### DIFF
--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -52,7 +52,7 @@ All inputs, no matter the type, when receiving focus, match the second selector 
 
 The specificity for a required input nested in an element with attribute `id="myApp"` is `1-2-1`, based on one ID, two pseudo-classes, and one element type.
 
-If the password input type is nested in an element with `id="myApp"` set, the specificity weight will be `1-2-1`, whether or not it has focus. Why is the specificity weight `1-2-1` rather than `0-1-1` or `0-1-0` in this case? Because the specificity weight comes from the matching selector with the greatest specificity weight. The weight is determined by comparing the values in the three columns, from left to right.
+If the password input type with required is nested in an element with `id="myApp"` set, the specificity weight will be `1-2-1`, whether or not it has focus. Why is the specificity weight `1-2-1` rather than `0-1-1` or `0-1-0` in this case? Because the specificity weight comes from the matching selector with the greatest specificity weight. The weight is determined by comparing the values in the three columns, from left to right.
 
 ```css
 [type="password"]             /* 0-1-0 */


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->
I have updated line: 55 from `If the password input type is nested in an element with id="myApp" set, the specificity weight will be 1-2-1.` to `If the password input type with required is nested in an element with `id="myApp"` set, the specificity weight will be `1-2-1``

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
More explicit and improves the explanation

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
Fixes #25890
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
